### PR TITLE
Fix sample code and missing emoji

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ following things to prepare.
 - [ ] 📺 Watch
       [Use Zoom for KCD Workshops](https://egghead.io/lessons/egghead-use-zoom-for-kcd-workshops)
       (~8 minutes).
-- [ ] Watch
+- [ ] 📺 Watch
       [Setup and Logistics for KCD Workshops](https://egghead.io/lessons/egghead-setup-and-logistics-for-kcd-workshops)
       (~24 minutes). Please do NOT skip this step.
 - [ ] 👋 Install the React DevTools

--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -37,7 +37,7 @@ const CountContext = React.createContext()
 
 function CountProvider(props) {
   const [count, setCount] = React.useState(0)
-  const value = React.useMemo([count, setCount], [count])
+  const value = React.useMemo(() => [count, setCount], [count])
   return <CountContext.Provider value={value} {...props} />
 }
 ```


### PR DESCRIPTION
This PR fixes two things:
- a missing emoji which triggered me the moment I saw it.
- the sample code for exercise 6 when using `React.useMemo`.

