### PR TITLE
Fix useUpdateGrid in Exercise 6.4

### DIFF
--- a/src/exercise/06.extra-4.js
+++ b/src/exercise/06.extra-4.js
@@ -30,7 +30,7 @@ const initialGrid = Array.from({length: 100}, () =>
 // const updateGrid = useUpdateGrid()
 // then later: updateGrid({rows, columns})
 // function useUpdateGrid() {
-//   return useRecoilCallback(({set}, {rows, columns}) => {
+//   return useRecoilCallback(({set}) => ({rows, columns}) => {
 //     for (let row = 0; row < rows; row++) {
 //       for (let column = 0; column < columns; column++) {
 //         if (Math.random() > 0.7) {

--- a/src/final/06.extra-4.js
+++ b/src/final/06.extra-4.js
@@ -18,7 +18,7 @@ const cellAtoms = atomFamily({
 })
 
 function useUpdateGrid() {
-  return useRecoilCallback(({set}, {rows, columns}) => {
+  return useRecoilCallback(({set}) => ({rows, columns}) => {
     for (let row = 0; row < rows; row++) {
       for (let column = 0; column < columns; column++) {
         if (Math.random() > 0.7) {


### PR DESCRIPTION
The `Update Grid Data` button and `Keep Grid Data updated` checkbox do not work, because the `useUpdateGrid` function has an error: The useRecoilCallback is invoked incorrectly (see [recoil 0.0.10 documentation](https://recoiljs.org/blog/2020/06/18/0.0.10-released/#userecoilcallback))