### PR TITLE
update recoil to 0.0.13

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15946,9 +15946,9 @@
       "integrity": "sha512-5b4XmKK4MEss63y0Lw0vn0Zn6G5kiHP88mUnD8UeEsyORj3sh1ghTH0/u6m1Ax9G2F4wUZrknlp6WlIsCvoXVA=="
     },
     "recoil": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.0.10.tgz",
-      "integrity": "sha512-+9gRqehw3yKETmoZbhSnWu4GO10HDb5xYf1CjLF1oXGK2uT6GX5Lu9mfTXwjxV/jXxEKx8MIRUUbgPxvbJ8SEw=="
+      "version": "0.0.13",
+      "resolved": "https://registry.npmjs.org/recoil/-/recoil-0.0.13.tgz",
+      "integrity": "sha512-2OToaQ8GR//KsdKdaEhMi04QKStLGRpk3qjC58iBpZpUtsByZ4dUy2UJtRcYuhnVlltGZ8HNwcEQRdFOS864SQ=="
     },
     "recursive-readdir": {
       "version": "2.2.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "react-spring": "^8.0.27",
     "react-use-gesture": "^7.0.16",
     "react-virtual": "^2.2.5",
-    "recoil": "0.0.10",
+    "recoil": "0.0.13",
     "topojson-client": "^3.1.0",
     "use-interval": "^1.2.1",
     "vanilla-tilt": "^1.7.0",


### PR DESCRIPTION
During development recoil has an error that slows down the startup time of the site. This is fixed in recoil 0.0.13.  
See [recoil issue](https://github.com/facebookexperimental/Recoil/issues/12)

![image](https://user-images.githubusercontent.com/12884134/95060558-b993e480-06fa-11eb-8e08-8945eeee11f5.png)

