### PR TITLE
Fix: Updated code hint message to fix a bug when hovering out of items list

### DIFF
--- a/src/exercise/04.js
+++ b/src/exercise/04.js
@@ -137,7 +137,7 @@ function App() {
     // 💰 scrollIntoView: () => {},
     // 🐨 when the highlightedIndex changes, then tell react-virtual to scroll
     // to that index.
-    // 💰 onHighlightedIndexChange: ({highlightedIndex}) => rowVirtualizer.scrollToIndex(highlightedIndex),
+    // 💰 onHighlightedIndexChange: ({highlightedIndex}) => highlightedIndex !== -1 && rowVirtualizer.scrollToIndex(highlightedIndex),
   })
 
   return (

--- a/src/final/04.js
+++ b/src/final/04.js
@@ -115,7 +115,7 @@ function App() {
     itemToString: item => (item ? item.name : ''),
     scrollIntoView: () => {},
     onHighlightedIndexChange: ({highlightedIndex}) =>
-      rowVirtualizer.scrollToIndex(highlightedIndex),
+      highlightedIndex !== -1 && rowVirtualizer.scrollToIndex(highlightedIndex),
   })
 
   return (


### PR DESCRIPTION
## Purpose 
Update code hint message to fix a bug that caused the items list to scroll to the top when hovering out of it.

## Reproduce 
1- go to `exercise/04.js` and follow the comments to solve the exercise or simply skip ahead to `final/04.js`
2- run the code and navigate to the example sandbox.
3- scroll the items list down (make sure that the mouse is still inside the boundaries of the list)
4- move the mouse out of the list and notice the list scrolling back to the top.
![scroll bug](https://user-images.githubusercontent.com/535126/95404301-f0454700-0914-11eb-91f9-4b261ac0c8b2.gif)

## Approach 
on debugging, I found that `onHighlightedIndexChange` returns `highlightedIndex` with value of `-1` when the mouse moves out of the list. 
so I simply updated the code suggestion in the example to prevent scrolling to the `highlightedIndex` if it equals to `-1`