### PR TITLE
Replace link to "Optimize Context Value" blogpost

### DIFF
--- a/src/exercise/05.md
+++ b/src/exercise/05.md
@@ -23,7 +23,7 @@ even though the `count` value itself may stay the same, all component consumers
 will be re-rendered.
 
 This can be problematic in certain scenarios. You can
-[read more about this here](https://github.com/kentcdodds/kentcdodds.com/blob/319db97260078ea4c263e75166f05e2cea21ccd1/content/blog/how-to-optimize-your-context-value/index.md).
+[read more about this here](https://kentcdodds.com/blog/how-to-optimize-your-context-value).
 
 The quick and easy solution to this problem is to memoize the value that you
 provide to the context provider:


### PR DESCRIPTION
Hey Kent! 👋 

Spotted a link linking to a blog post markdown file on GitHub instead of the blog post itself.
This PR updates that link.

Loving the course so far!
Cheers! 😊 