### PR TITLE
Update 05.md with the correct link

### DIFF
--- a/src/exercise/05.md
+++ b/src/exercise/05.md
@@ -23,7 +23,7 @@ even though the `count` value itself may stay the same, all component consumers
 will be re-rendered.
 
 This can be problematic in certain scenarios. You can
-[read more about this here](https://github.com/kentcdodds/kentcdodds.com/blob/319db97260078ea4c263e75166f05e2cea21ccd1/content/blog/how-to-optimize-your-context-value/index.md).
+[read more about this here](https://kentcdodds.com/blog/how-to-optimize-your-context-value).
 
 The quick and easy solution to this problem is to memoize the value that you
 provide to the context provider:

--- a/src/exercise/05.md
+++ b/src/exercise/05.md
@@ -23,7 +23,8 @@ even though the `count` value itself may stay the same, all component consumers
 will be re-rendered.
 
 This can be problematic in certain scenarios. You can
-[read more about this here](https://kentcdodds.com/blog/how-to-optimize-your-context-value).
+[read more about this here](https://github.com/kentcdodds/kentcdodds.com/blob/319db97260078ea4c263e75166f05e2cea21ccd1/content/blog/how-to-optimize-your-context-value/index.md)
+(yes, this is intentionally linking to an old version of the blog post).
 
 The quick and easy solution to this problem is to memoize the value that you
 provide to the context provider:


### PR DESCRIPTION
While working through fifth exercise I've noticed that the url is pointing to the github remote which contains blog post content. I've made a minor PR where I've replaced it with the correct url.