### PR TITLE
Fix typo in the window large list exercise

### DIFF
--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -70,7 +70,7 @@ function MyListOfData({items}) {
   })
 
   return (
-    <ul ref={listRef} style={{display: 'relative', height: 300}}>
+    <ul ref={listRef} style={{position: 'relative', height: 300}}>
       <li style={{height: rowVirtualizer.totalSize}} />
       {rowVirtualizer.virtualItems.map(({index, size, start}) => {
         const item = items[index]


### PR DESCRIPTION
There was a typo in the excercise as the `display: relative` value
doesn't actually exist and the `<li>` items below are going to be
positioned in an **absolute** way. The correct way of creating this
container is positioning it as **relative**.