### PR TITLE
Removed confusing comment about deleting index argument

### DIFF
--- a/src/exercise/04.js
+++ b/src/exercise/04.js
@@ -43,7 +43,6 @@ function Menu({
         - size: set the "height" style to this value
         - start: this is how many pixels from the scrollTop this item should be
       */}
-      {/* 💣 delete the second argument of "index", you can get that from the virtualRow object */}
       {items.map((item, index) => (
         <ListItem
           key={item.id}


### PR DESCRIPTION
Removed comment about deleting the 2nd argument (index), since we're not keeping the first argument (item) either. Infact, we are replacing them both with the 3 properties that Marty the Moneybag tells us about in the comment above.