### PR TITLE
update unnecessary-rerenders to not memoize CountButton

### DIFF
--- a/src/examples/unnecessary-rerenders.js
+++ b/src/examples/unnecessary-rerenders.js
@@ -32,3 +32,8 @@ function Example() {
 }
 
 export default Example
+
+/*
+eslint
+  no-func-assign: 0,
+*/

--- a/src/exercise/03.md
+++ b/src/exercise/03.md
@@ -106,7 +106,6 @@ So here's how we can improve our example:
 function CountButton({count, onClick}) {
   return <button onClick={onClick}>{count}</button>
 }
-CountButton = React.memo(CountButton)
 
 function NameInput({name, onNameChange}) {
   return (
@@ -127,10 +126,16 @@ ones.
 
 Again, I want to mention that people can make the mistake of wrapping
 _everything_ in `React.memo` which can actually slow down your app in some cases
-and in all cases it makes your code more complex. So it's much better to use it
-more intentionally and further, there are other things you can do to reduce the
-amount of unnecessary re-renders throughout your application (which we'll talk
-about more later).
+and in all cases it makes your code more complex.
+
+That's why we didn't memoize `<CountButton />`, its parent is re-initializing
+`increment` every render, but `React.memo` relies on the same props each call to
+prevent unnecessary renders. It wouldn't work without wrapping `increment` in
+`React.useCallback`.
+
+It's much better to use `React.memo` more intentionally and further, there are other things
+you can do to reduce the amount of unnecessary re-renders throughout your application
+(which we'll talk about more later).
 
 ## Exercise
 


### PR DESCRIPTION
As discussed in #78 this is my proposed solution to why `<CountButton />` shouldn't be memoized in `03.md`

I also copied the eslint comment from `03.js` to `unnecessary-rerenders.js`, so that people playing around with the solution don't get those warning.