### PR TITLE
2 changes to exercise 6 - extra credit 2

### DIFF
--- a/src/exercise/06.md
+++ b/src/exercise/06.md
@@ -101,9 +101,6 @@ We could rename the `Cell` component to `CellImpl` (Impl is short for
 update, `Cell` is re-rendered, and it forwards the `cell` to `CellImpl` which is
 memoized and will therefore only re-render when `cell` changes.
 
-You may find it easier to just undo all your work so far and start over from
-scratch to implement this.
-
 Be sure to double-check the experience and make sure your changes are actually
 improving the situation. Sometimes this will help, and other times it doesn't do
 much to help and only leaves you with a more complex codebase for no reason!


### PR DESCRIPTION
Hi,

* there was a paragraph that probably shouldn't be there in `06.md`
* removed the memozing of the middle-layer component, because it always updates as it consumes the AppState via `useAppState()`

(more info in the commit-messages)
I *think* I'm correct with the second one, but not entirely, that's why I made it into 2 commits. If they are both correct I can squash them together if you want.