### PR TITLE
updated false-positive test for exercise 1

### DIFF
--- a/src/__tests__/01.js
+++ b/src/__tests__/01.js
@@ -1,6 +1,6 @@
 import * as React from 'react'
 import {alfredTip} from '@kentcdodds/react-workshop-app/test-utils'
-import {render, screen, act} from '@testing-library/react'
+import {render, screen} from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import App from '../final/01'
 // import App from '../exercise/01'
@@ -16,18 +16,15 @@ beforeEach(() => {
   }
 })
 
-test('loads the tile component asynchronously', async () => {
+test('loads the globe component asynchronously', async () => {
   render(<App />)
+
+  userEvent.click(screen.getByLabelText(/show globe/))
 
   alfredTip(
     () => expect(screen.queryByTitle(/globe/i)).not.toBeInTheDocument(),
-    'The tilt component must be loaded asynchronously via React.lazy and React.Suspense',
+    'The globe component must be loaded asynchronously via React.lazy and React.Suspense',
   )
-
-  // TODO: figure out why act is needed here because it should not be...
-  await act(async () => {
-    userEvent.click(screen.getByLabelText(/show globe/))
-  })
 
   expect(await screen.findByTitle(/globe/i)).toBeInTheDocument()
 })


### PR DESCRIPTION
Hi Kent & all EpicReact friends! 👋 

I found a false-positive test in exercise 1.

**Issue:**
The test of exercise 1 is passing from the start when using the exercise-file (`exercise/01.js`) in the test, even though the Globe-component isn't loaded asynchronously. 

![react_perf_exercise_1_false_positive_test](https://user-images.githubusercontent.com/10499067/118487879-73384680-b71b-11eb-9a1b-2009534d06a8.png) 

It seems like the issue was that the test expects the title of the Globe-component to not be in the document before we have clicked the "show globe"-checkbox. In this PR I moved it so that it is expected after we click the checkbox. Now the test fails as expected:

![react_perf_exercise_1_test_failing](https://user-images.githubusercontent.com/10499067/118488544-2012c380-b71c-11eb-92fe-6db7bebc7e1d.png)

If I use`final/01` (where we load the component async) in the test, it still passes as it should.

This is my first time contributing to an open-source project, so please let me know if I have missed something. 
Thanks! 🙌 
