### PR TITLE
Remove cell var from 06 extra-3 final to match video

### DIFF
--- a/src/final/06.extra-3.js
+++ b/src/final/06.extra-3.js
@@ -109,8 +109,7 @@ function withStateSlice(Comp, slice) {
   const MemoComp = React.memo(Comp)
   function Wrapper(props, ref) {
     const state = useAppState()
-    const cell = slice(state, props)
-    return <MemoComp ref={ref} state={cell} {...props} />
+    return <MemoComp ref={ref} state={slice(state, props)} {...props} />
   }
   Wrapper.displayName = `withStateSlice(${Comp.displayName || Comp.name})`
   return React.memo(React.forwardRef(Wrapper))


### PR DESCRIPTION
The `cell` was left in `withStateSlice` in the final which confused me when looking at it as it was less generic.
Noticed it wasn't left in the video so updated the file to match.