### PR TITLE
Update Devtools Coverage link

### DIFF
--- a/src/exercise/01.md
+++ b/src/exercise/01.md
@@ -65,7 +65,7 @@ function App() {
 
 🦉 One great way to analyze your app to determine the need/benefit of code
 splitting for a certain feature/page/interaction, is to use
-[the "Coverage" feature of the developer tools](https://developers.google.com/web/tools/chrome-devtools/coverage).
+[the "Coverage" feature of the developer tools](https://developer.chrome.com/docs/devtools/coverage).
 
 ## Exercise
 


### PR DESCRIPTION
The links to Chrome devtools have changed - the coverage link having updated to: https://developer.chrome.com/docs/devtools/coverage/
Will update if I come across more outdated links as I go!

Thanks :) 