### PR TITLE
Fix Badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,7 @@ Thank you! https://kcd.im/rp-ws-feedback
 [npm]: https://www.npmjs.com/
 [node]: https://nodejs.org
 [git]: https://git-scm.com/
-[build-badge]: https://img.shields.io/github/workflow/status/kentcdodds/react-performance/validate/main?logo=github&style=flat-square
+[build-badge]: https://img.shields.io/github/actions/workflow/status/kentcdodds/react-performance/validate.yml?branch=main&logo=github&style=flat-square
 [build]: https://github.com/kentcdodds/react-performance/actions?query=workflow%3Avalidate
 [license-badge]: https://img.shields.io/badge/license-GPL%203.0%20License-blue.svg?style=flat-square
 [license]: https://github.com/kentcdodds/react-performance/blob/main/LICENSE


### PR DESCRIPTION
The build badge is not working. I fixed it according to the instructions at https://github.com/badges/shields/issues/8671