### PR TITLE
Update references to @tanstack/react-virtual

### DIFF
--- a/src/exercise/04.md
+++ b/src/exercise/04.md
@@ -1,10 +1,10 @@
-# Window large lists with react-virtual
+# Window large lists with @tanstack/react-virtual
 
 ## 📝 Your Notes
 
 Elaborate on your learnings here in `src/exercise/04.md`
 
-> NOTE: We're going to be using a library called `react-virtual`. Some of you
+> NOTE: We're going to be using a library called `@tanstack/react-virtual`. Some of you
 > may have used this before and others may not have used it or anything else
 > like it. I normally like to build up to abstractions like this one by building
 > a simple version of the abstraction ourselves, but that would be a workshop
@@ -46,8 +46,8 @@ doing this "lazy" just-in-time rendering.
 This is a concept called "windowing" and in some cases it can really speed up
 your components that render lots of data. There are various libraries in the
 React ecosystem for solving this problem. My personal favorite is called
-`react-virtual`. Here's an example of how you would adapt a list to use
-`react-virtual`'s `useVirtual` hook:
+`@tanstack/react-virtual`. Here's an example of how you would adapt a list to use
+`@tanstack/react-virtual`'s `useVirtual` hook:
 
 ```jsx
 // before
@@ -105,7 +105,7 @@ use to determine what size they each should be, and then it will give you back
 `virtualItems` and a `totalSize` which you can then use to only render the items
 the user should be able to see within the window.
 
-[react-virtual](https://github.com/tannerlinsley/react-virtual) has some really
+[@tanstack/react-virtual](https://github.com/TanStack/virtual) has some really
 awesome capabilities for all sorts of lists (including variable sizes and
 grids). Definitely give it a look to speed up your lists.
 
@@ -129,7 +129,7 @@ need to do. You need to window this stuff! Run less code, and speed up your
 component.
 
 Note that 💰 Marty the Money Bag has done a tiny bit of work for you that's
-specific to how you integrate Downshift and react-virtual. He's done a good job
+specific to how you integrate `Downshift` and `@tanstack/react-virtual`. He's done a good job
 documenting what he's done so you can read about the changes he made if you
 want. 🐨 Kody the Koala will be there to help you know what changes you need to
 make. Good luck!


### PR DESCRIPTION
`react-virtual` has been moved to `@tanstack/react-virtual`. For this reason, I have renamed the references and updated the url to the github repository.